### PR TITLE
Stop pinning the version of python-neo4j-driver since the latest now works properly

### DIFF
--- a/docker/Dockerfile-tests
+++ b/docker/Dockerfile-tests
@@ -19,9 +19,6 @@ RUN dnf -y install \
   python3-koji \
   python2-mock \
   python3-mock \
-  # Until 1.6.0 is supported, we need to hardcode these two entries
-  python2-neo4j-driver-1.5.3 \
-  python3-neo4j-driver-1.5.3 \
   python2-neomodel \
   python3-neomodel \
   python2-pyOpenSSL \


### PR DESCRIPTION
So for a little while, python-neomodel only supported python-neo4j-driver v1.5.3, so we had to pin to that version. Now that I released a newer version of python-neomodel that supports the latest python-neo4j-driver, we can stop pinning the version.