### PR TITLE
Add the NVR to container builds that don't have them in Neo4j

### DIFF
--- a/estuary_updater/handlers/base.py
+++ b/estuary_updater/handlers/base.py
@@ -3,8 +3,13 @@
 from __future__ import unicode_literals
 
 import abc
+from datetime import datetime
+import json
 
 import neomodel
+import koji
+from estuary.models.koji import KojiBuild, ContainerKojiBuild
+from estuary.models.user import User
 
 from estuary_updater import log
 
@@ -20,6 +25,7 @@ class BaseHandler(object):
 
         :param dict config: the fedmsg configuration
         """
+        self._koji_session = None
         self.config = config
         if config.get('estuary_updater.neo4j_url'):
             neomodel.config.DATABASE_URL = config['estuary_updater.neo4j_url']
@@ -48,3 +54,83 @@ class BaseHandler(object):
         :param dict msg: a message to be processed
         """
         pass
+
+    @property
+    def koji_session(self):
+        """
+        Get a cached Koji session but initialize the connection first if needed.
+
+        :return: a Koji session object
+        :rtype: koji.ClientSession
+        """
+        if not self._koji_session:
+            self._koji_session = koji.ClientSession(self.config['estuary_updater.koji_url'])
+        return self._koji_session
+
+    def is_container_build(self, build_info):
+        """
+        Check whether a Koji build is a container build.
+
+        :param KojiBuild build_info: build info from the Koji API
+        :return: boolean value indicating whether the build is a container build
+        :rtype: bool
+        """
+        package_name = build_info['package_name']
+        # Checking a heuristic for determining if a build is a container build since, currently
+        # there is no definitive way to do it.
+        if build_info['extra'] and (
+                build_info['extra'].get('container_koji_build_id') or
+                build_info['extra'].get('container_koji_task_id')):
+            return True
+        # Checking another heuristic for determining if a build is a container build since
+        # currently there is no definitive way to do it.
+        elif (package_name.endswith('-container') or package_name.endswith('-docker')):
+            return True
+        else:
+            return False
+
+    def get_or_create_build(self, identifier, original_nvr=None, force_container_label=False):
+        """
+        Get a Koji build from Neo4j, or create it if it does not exist in Neo4j.
+
+        :param str/int identifier: an NVR (str) or build ID (int)
+        :kwarg str original_nvr: original_nvr property for the ContainerKojiBuild
+        :kwarg bool force_container_label: when true, this skips the check to see if the build is a
+        container and just creates the build with the ContainerKojiBuild label
+        :rtype: KojiBuild
+        :return: the Koji Build retrieved or created from Neo4j
+        """
+        try:
+            koji_build_info = self.koji_session.getBuild(identifier, strict=True)
+        except Exception:
+            log.error('Failed to get brew build using the identifier {0}'.format(identifier))
+            raise
+
+        build_params = {
+            'completion_time': datetime.fromtimestamp(int(koji_build_info['completion_ts'])),
+            'creation_time': datetime.fromtimestamp(int(koji_build_info['creation_ts'])),
+            'epoch': koji_build_info['epoch'],
+            'extra': json.dumps(koji_build_info['extra']),
+            'id_': str(koji_build_info['id']),
+            'name': koji_build_info['package_name'],
+            'release': koji_build_info['release'],
+            'start_time': datetime.fromtimestamp(int(koji_build_info['start_ts'])),
+            'state': koji_build_info['state'],
+            'version': koji_build_info['version']
+        }
+
+        owner = User.create_or_update({
+            'username': koji_build_info['owner_name'],
+            'email': '{0}@redhat.com'.format(koji_build_info['owner_name'])
+        })[0]
+
+        if force_container_label or self.is_container_build(koji_build_info):
+            if original_nvr:
+                build_params['original_nvr'] = original_nvr
+            koji_build = ContainerKojiBuild.create_or_update(build_params)[0]
+        else:
+            koji_build = KojiBuild.create_or_update(build_params)[0]
+
+        koji_build.owner.connect(owner)
+
+        return koji_build

--- a/estuary_updater/handlers/freshmaker.py
+++ b/estuary_updater/handlers/freshmaker.py
@@ -101,6 +101,7 @@ class FreshmakerHandler(BaseHandler):
         :return: the created/updated ContainerKojiBuild or None if it cannot be created
         :rtype: ContainerKojiBuild or None
         """
+        # build_id in Freshmaker is actually the task_id
         if not build['build_id']:
             log.debug('Skipping build update for event {0} because no build ID exists.'.format(
                 event_id))

--- a/estuary_updater/handlers/freshmaker.py
+++ b/estuary_updater/handlers/freshmaker.py
@@ -103,7 +103,7 @@ class FreshmakerHandler(BaseHandler):
         """
         # build_id in Freshmaker is actually the task_id
         if not build['build_id']:
-            log.debug('Skipping build update for event {0} because no build ID exists.'.format(
+            log.debug('Skipping build update for event {0} because build_id is not set'.format(
                 event_id))
             return None
         try:

--- a/estuary_updater/handlers/freshmaker.py
+++ b/estuary_updater/handlers/freshmaker.py
@@ -96,7 +96,7 @@ class FreshmakerHandler(BaseHandler):
         """
         Use the Koji Task Result to create or update a ContainerKojiBuild.
 
-        :param dict build: the build being created or updated
+        :param dict build: the build represented in Freshmaker being created or updated
         :param int event_id: the id of the Freshmaker event
         :return: the created/updated ContainerKojiBuild or None if it cannot be created
         :rtype: ContainerKojiBuild or None

--- a/estuary_updater/handlers/freshmaker.py
+++ b/estuary_updater/handlers/freshmaker.py
@@ -106,11 +106,13 @@ class FreshmakerHandler(BaseHandler):
             log.debug('Skipping build update for event {0} because build_id is not set'.format(
                 event_id))
             return None
+
         try:
             koji_task_result = self.koji_session.getTaskResult(build['build_id'])
         except Exception:
             log.error('Failed to get the Koji task result with ID {0}'.format(build['build_id']))
             raise
+
         koji_build_id = koji_task_result['koji_builds'][0]
         build_params = {
             'id_': koji_build_id,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,9 +2,12 @@
 
 from __future__ import unicode_literals
 import os
+from datetime import datetime
 
 import pytest
 from neomodel import config as neomodel_config, db as neo4j_db
+from estuary.models.koji import ContainerKojiBuild
+import pytz
 
 from estuary_updater.consumer import EstuaryUpdater
 
@@ -33,7 +36,7 @@ def consumer():
 
 
 @pytest.fixture
-def mock_build_one():
+def mock_getBuild_one():
     """Return a mock build in the format of koji.ClientSession.getBuild."""
     return {
         'completion_ts': 1529094398.0,
@@ -52,7 +55,27 @@ def mock_build_one():
 
 
 @pytest.fixture
-def mock_build_two():
+def cb_one():
+    """Return a KojiContainerBuild matching mock_getBuild_one."""
+    return ContainerKojiBuild.get_or_create({
+        'completion_time': datetime(2018, 6, 15, 20, 26, 38, tzinfo=pytz.utc),
+        'creation_time': datetime(2018, 6, 15, 20, 20, 38, tzinfo=pytz.utc),
+        'epoch': 'epoch',
+        'extra': '{"container_koji_task_id": 17511743}',
+        'id_': '710916',
+        'name': 'e2e-container-test-product-container',
+        'package_name': 'openstack-zaqar-container',
+        'original_nvr': 'e2e-container-test-product-container-7.3-210.1523551880',
+        'owner_name': 'emusk',
+        'release': '36.1528968216',
+        'start_time': datetime(2018, 6, 15, 20, 21, 38, tzinfo=pytz.utc),
+        'state': 3,
+        'version': '7.4'
+    })[0]
+
+
+@pytest.fixture
+def mock_getBuild_two():
     """Return a mock build in the format of koji.ClientSession.getBuild."""
     return {
         'completion_ts': 1529094398.0,
@@ -71,7 +94,27 @@ def mock_build_two():
 
 
 @pytest.fixture
-def mock_build_three():
+def cb_two():
+    """Return a KojiContainerBuild matching mock_getBuild_two."""
+    return ContainerKojiBuild.get_or_create({
+        'completion_time': datetime(2018, 6, 15, 20, 26, 38, tzinfo=pytz.utc),
+        'creation_time': datetime(2018, 6, 15, 20, 20, 38, tzinfo=pytz.utc),
+        'epoch': 'epoch',
+        'extra': '{"container_koji_task_id": 123456}',
+        'id_': '123456',
+        'name': 'e2e-container-test-product-container',
+        'package_name': 'openstack-zaqar-container',
+        'original_nvr': 'e2e-container-test-product-container-7.3-210.1523551880',
+        'owner_name': 'emusk',
+        'release': '37.1528968216',
+        'start_time': datetime(2018, 6, 15, 20, 21, 38, tzinfo=pytz.utc),
+        'state': 3,
+        'version': '8.4'
+    })[0]
+
+
+@pytest.fixture
+def mock_getBuild_three():
     """Return a mock build in the format of koji.ClientSession.getBuild."""
     return {
         'completion_ts': 1529094398.0,
@@ -87,3 +130,23 @@ def mock_build_three():
         'start_ts': 1529094098.0,
         'state': 0
     }
+
+
+@pytest.fixture
+def cb_three():
+    """Return a KojiContainerBuild matching mock_getBuild_three."""
+    return ContainerKojiBuild.get_or_create({
+        'completion_time': datetime(2018, 6, 15, 20, 26, 38, tzinfo=pytz.utc),
+        'creation_time': datetime(2018, 6, 15, 20, 20, 38, tzinfo=pytz.utc),
+        'epoch': 'epoch',
+        'extra': '{"container_koji_task_id": 234567 }',
+        'id_': '234567',
+        'name': 'e2e-container-test-product-container',
+        'package_name': 'openstack-zaqar-container',
+        'original_nvr': 'e2e-container-test-product-container-7.3-210.1523551880',
+        'owner_name': 'emusk',
+        'release': '38.1528968216',
+        'start_time': datetime(2018, 6, 15, 20, 21, 38, tzinfo=pytz.utc),
+        'state': 1,
+        'version': '9.4'
+    })[0]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -30,3 +30,60 @@ def consumer():
         config = {}
 
     return EstuaryUpdater(FakeHub())
+
+
+@pytest.fixture
+def mock_build_one():
+    """Return a mock build in the format of koji.ClientSession.getBuild."""
+    return {
+        'completion_ts': 1529094398.0,
+        'creation_ts': 1529094038.0,
+        'epoch': 'epoch',
+        'extra': {'container_koji_task_id': 17511743},
+        'id': 710916,
+        'name': 'e2e-container-test-product-container',
+        'package_name': 'e2e-container-test-product-container',
+        'owner_name': 'emusk',
+        'release': '36.1528968216',
+        'version': '7.4',
+        'start_ts': 1529094098.0,
+        'state': 0
+    }
+
+
+@pytest.fixture
+def mock_build_two():
+    """Return a mock build in the format of koji.ClientSession.getBuild."""
+    return {
+        'completion_ts': 1529094398.0,
+        'creation_ts': 1529094038.0,
+        'epoch': 'epoch',
+        'extra': {'container_koji_task_id': 17511743},
+        'id': 123456,
+        'name': 'e2e-container-test-product-container',
+        'package_name': 'e2e-container-test-product-container',
+        'owner_name': 'emusk',
+        'release': '37.1528968216',
+        'version': '8.4',
+        'start_ts': 1529094098.0,
+        'state': 0
+    }
+
+
+@pytest.fixture
+def mock_build_three():
+    """Return a mock build in the format of koji.ClientSession.getBuild."""
+    return {
+        'completion_ts': 1529094398.0,
+        'creation_ts': 1529094038.0,
+        'epoch': 'epoch',
+        'extra': {'container_koji_task_id': 17511743},
+        'id': 234567,
+        'name': 'e2e-container-test-product-container',
+        'package_name': 'e2e-container-test-product-container',
+        'owner_name': 'emusk',
+        'release': '38.1528968216',
+        'version': '9.4',
+        'start_ts': 1529094098.0,
+        'state': 0
+    }

--- a/tests/handlers/test_errata.py
+++ b/tests/handlers/test_errata.py
@@ -7,7 +7,7 @@ from os import path
 import datetime
 
 from estuary.models.errata import Advisory
-from estuary.models.koji import KojiBuild
+from estuary.models.koji import KojiBuild, ContainerKojiBuild
 from estuary.models.user import User
 import mock
 import pytz
@@ -77,16 +77,17 @@ def test_builds_added_handler(mock_koji_cs):
     """Test the Errata handler when it receives a new builds added message."""
     mock_koji_session = mock.Mock()
     mock_koji_session.getBuild.return_value = {
-        'completion_time': datetime.datetime(2018, 6, 15, 15, 26, 38, tzinfo=pytz.utc),
-        'creation_time': datetime.datetime(2018, 6, 15, 15, 26, 38, tzinfo=pytz.utc),
+        'completion_ts': 1529094398.0,
+        'creation_ts': 1529094038.0,
         'epoch': 'epoch',
-        'extra': 'extra',
+        'extra': {'container_koji_task_id': 17511743},
         'id': 123456,
+        'name': 'openstack-zaqar-container',
         'package_name': 'openstack-zaqar-container',
         'owner_name': 'emusk',
         'version': '13.0',
         'release': '45',
-        'start_time': datetime.datetime(2018, 6, 15, 15, 26, 38, tzinfo=pytz.utc),
+        'start_ts': 1529094098.0,
         'state': 1
     }
     mock_koji_cs.return_value = mock_koji_session
@@ -108,12 +109,12 @@ def test_builds_added_handler(mock_koji_cs):
     assert build.name == 'openstack-zaqar-container'
     assert build.version == '13.0'
     assert build.release == '45'
-    assert build.completion_time == datetime.datetime(2018, 6, 15, 15, 26, 38, tzinfo=pytz.utc)
-    assert build.creation_time == datetime.datetime(2018, 6, 15, 15, 26, 38, tzinfo=pytz.utc)
+    assert build.completion_time == datetime.datetime(2018, 6, 15, 20, 26, 38, tzinfo=pytz.utc)
+    assert build.creation_time == datetime.datetime(2018, 6, 15, 20, 20, 38, tzinfo=pytz.utc)
     assert build.epoch == 'epoch'
-    assert build.extra == 'extra'
+    assert build.extra == '{"container_koji_task_id": 17511743}'
     assert build.id_ == '123456'
-    assert build.start_time == datetime.datetime(2018, 6, 15, 15, 26, 38, tzinfo=pytz.utc)
+    assert build.start_time == datetime.datetime(2018, 6, 15, 20, 21, 38, tzinfo=pytz.utc)
     assert build.state == 1
 
     assert advisory.attached_builds.is_connected(build)
@@ -125,32 +126,34 @@ def test_builds_removed_handler(mock_koji_cs):
     """Test the Errata handler when it receives a new builds removed message."""
     mock_koji_session = mock.Mock()
     mock_koji_session.getBuild.return_value = {
-        'completion_time': datetime.datetime(2018, 6, 15, 15, 26, 38, tzinfo=pytz.utc),
-        'creation_time': datetime.datetime(2018, 6, 15, 15, 26, 38, tzinfo=pytz.utc),
+        'completion_ts': 1529094398.0,
+        'creation_ts': 1529094038.0,
         'epoch': 'epoch',
-        'extra': 'extra',
+        'extra': {'container_koji_task_id': 17511743},
         'id': 123456,
+        'name': 'openstack-zaqar-container',
         'package_name': 'openstack-zaqar-container',
         'owner_name': 'emusk',
         'version': '13.0',
         'release': '45',
-        'start_time': datetime.datetime(2018, 6, 15, 15, 26, 38, tzinfo=pytz.utc),
+        'start_ts': 1529094098.0,
         'state': 1
     }
     mock_koji_cs.return_value = mock_koji_session
 
     advisory = Advisory.get_or_create({'id_': '34983'})[0]
-    build = KojiBuild.get_or_create({
-        'completion_time': datetime.datetime(2018, 6, 15, 15, 26, 38, tzinfo=pytz.utc),
-        'creation_time': datetime.datetime(2018, 6, 15, 15, 26, 38, tzinfo=pytz.utc),
+    build = ContainerKojiBuild.get_or_create({
+        'completion_time': datetime.datetime(2018, 6, 15, 20, 26, 38, tzinfo=pytz.utc),
+        'creation_time': datetime.datetime(2018, 6, 15, 20, 20, 38, tzinfo=pytz.utc),
         'epoch': 'epoch',
-        'extra': 'extra',
+        'extra': '{"container_koji_task_id": 17511743}',
         'id_': '123456',
+        'name': 'openstack-zaqar-container',
         'package_name': 'openstack-zaqar-container',
         'owner_name': 'emusk',
         'version': '13.0',
         'release': '45',
-        'start_time': datetime.datetime(2018, 6, 15, 15, 26, 38, tzinfo=pytz.utc),
+        'start_time': datetime.datetime(2018, 6, 15, 20, 21, 38, tzinfo=pytz.utc),
         'state': 1
     })[0]
 

--- a/tests/handlers/test_errata.py
+++ b/tests/handlers/test_errata.py
@@ -7,7 +7,7 @@ from os import path
 import datetime
 
 from estuary.models.errata import Advisory
-from estuary.models.koji import KojiBuild, ContainerKojiBuild
+from estuary.models.koji import KojiBuild
 from estuary.models.user import User
 import mock
 import pytz
@@ -73,23 +73,11 @@ def test_activity_status_handler():
 
 
 @mock.patch('koji.ClientSession')
-def test_builds_added_handler(mock_koji_cs):
+def test_builds_added_handler(mock_koji_cs, mock_getBuild_one):
     """Test the Errata handler when it receives a new builds added message."""
     mock_koji_session = mock.Mock()
-    mock_koji_session.getBuild.return_value = {
-        'completion_ts': 1529094398.0,
-        'creation_ts': 1529094038.0,
-        'epoch': 'epoch',
-        'extra': {'container_koji_task_id': 17511743},
-        'id': 123456,
-        'name': 'openstack-zaqar-container',
-        'package_name': 'openstack-zaqar-container',
-        'owner_name': 'emusk',
-        'version': '13.0',
-        'release': '45',
-        'start_ts': 1529094098.0,
-        'state': 1
-    }
+    mock_getBuild_one['state'] = 1
+    mock_koji_session.getBuild.return_value = mock_getBuild_one
     mock_koji_cs.return_value = mock_koji_session
 
     advisory = Advisory.get_or_create({'id_': '34983'})[0]
@@ -103,17 +91,17 @@ def test_builds_added_handler(mock_koji_cs):
     # Run the handler
     handler.handle(msg)
 
-    build = KojiBuild.nodes.get_or_none(id_=123456)
+    build = KojiBuild.nodes.get_or_none(id_='710916')
     owner = User.nodes.get_or_none(username='emusk')
     assert build is not None
-    assert build.name == 'openstack-zaqar-container'
-    assert build.version == '13.0'
-    assert build.release == '45'
+    assert build.name == 'e2e-container-test-product-container'
+    assert build.version == '7.4'
+    assert build.release == '36.1528968216'
     assert build.completion_time == datetime.datetime(2018, 6, 15, 20, 26, 38, tzinfo=pytz.utc)
     assert build.creation_time == datetime.datetime(2018, 6, 15, 20, 20, 38, tzinfo=pytz.utc)
     assert build.epoch == 'epoch'
     assert build.extra == '{"container_koji_task_id": 17511743}'
-    assert build.id_ == '123456'
+    assert build.id_ == '710916'
     assert build.start_time == datetime.datetime(2018, 6, 15, 20, 21, 38, tzinfo=pytz.utc)
     assert build.state == 1
 
@@ -122,42 +110,15 @@ def test_builds_added_handler(mock_koji_cs):
 
 
 @mock.patch('koji.ClientSession')
-def test_builds_removed_handler(mock_koji_cs):
+def test_builds_removed_handler(mock_koji_cs, mock_getBuild_one, cb_one):
     """Test the Errata handler when it receives a new builds removed message."""
     mock_koji_session = mock.Mock()
-    mock_koji_session.getBuild.return_value = {
-        'completion_ts': 1529094398.0,
-        'creation_ts': 1529094038.0,
-        'epoch': 'epoch',
-        'extra': {'container_koji_task_id': 17511743},
-        'id': 123456,
-        'name': 'openstack-zaqar-container',
-        'package_name': 'openstack-zaqar-container',
-        'owner_name': 'emusk',
-        'version': '13.0',
-        'release': '45',
-        'start_ts': 1529094098.0,
-        'state': 1
-    }
+    mock_getBuild_one['state'] = 1
+    mock_koji_session.getBuild.return_value = mock_getBuild_one
     mock_koji_cs.return_value = mock_koji_session
 
     advisory = Advisory.get_or_create({'id_': '34983'})[0]
-    build = ContainerKojiBuild.get_or_create({
-        'completion_time': datetime.datetime(2018, 6, 15, 20, 26, 38, tzinfo=pytz.utc),
-        'creation_time': datetime.datetime(2018, 6, 15, 20, 20, 38, tzinfo=pytz.utc),
-        'epoch': 'epoch',
-        'extra': '{"container_koji_task_id": 17511743}',
-        'id_': '123456',
-        'name': 'openstack-zaqar-container',
-        'package_name': 'openstack-zaqar-container',
-        'owner_name': 'emusk',
-        'version': '13.0',
-        'release': '45',
-        'start_time': datetime.datetime(2018, 6, 15, 20, 21, 38, tzinfo=pytz.utc),
-        'state': 1
-    })[0]
-
-    advisory.attached_builds.connect(build)
+    advisory.attached_builds.connect(cb_one)
 
     with open(path.join(message_dir, 'errata', 'builds_removed.json'), 'r') as f:
         msg = json.load(f)
@@ -169,6 +130,4 @@ def test_builds_removed_handler(mock_koji_cs):
     handler.handle(msg)
 
     assert advisory is not None
-    assert build is not None
-
-    assert not advisory.attached_builds.is_connected(build)
+    assert not advisory.attached_builds.is_connected(cb_one)

--- a/tests/handlers/test_freshmaker.py
+++ b/tests/handlers/test_freshmaker.py
@@ -4,11 +4,13 @@ from __future__ import unicode_literals
 
 import json
 from os import path
+from datetime import datetime
 
 from estuary.models.freshmaker import FreshmakerEvent
 from estuary.models.errata import Advisory
 from estuary.models.koji import ContainerKojiBuild
 import mock
+import pytz
 
 from tests import message_dir
 from estuary_updater.handlers.freshmaker import FreshmakerHandler
@@ -16,7 +18,7 @@ from estuary_updater import config
 
 
 @mock.patch('koji.ClientSession')
-def test_event_to_building(mock_koji_cs):
+def test_event_to_building(mock_koji_cs, mock_build_one, mock_build_two, mock_build_three):
     """Test the Freshmaker handler when it receives an event to building message."""
     mock_koji_session = mock.Mock()
     mock_koji_session.getTaskResult.side_effect = [
@@ -30,6 +32,7 @@ def test_event_to_building(mock_koji_cs):
             'koji_builds': ['234567']
         }
     ]
+    mock_koji_session.getBuild.side_effect = [mock_build_one, mock_build_two, mock_build_three]
     mock_koji_cs.return_value = mock_koji_session
     # Load the message to pass to the handler
     with open(path.join(message_dir, 'freshmaker', 'event_to_building.json'), 'r') as f:
@@ -58,28 +61,37 @@ def test_event_to_building(mock_koji_cs):
     assert advisory is not None
     assert event.triggered_by_advisory.is_connected(advisory)
 
-    build = ContainerKojiBuild.nodes.get_or_none(id_=710916)
+    build = ContainerKojiBuild.nodes.get_or_none(id_='710916')
     orig_nvr = 'e2e-container-test-product-container-7.5-129'
     assert build is not None
     assert build.original_nvr == orig_nvr
+    assert build.name == 'e2e-container-test-product-container'
+    assert build.release == '36.1528968216'
+    assert build.version == '7.4'
     assert event.triggered_container_builds.is_connected(build)
     assert build.state == 0
-    build = ContainerKojiBuild.nodes.get_or_none(id_=123456)
+    build = ContainerKojiBuild.nodes.get_or_none(id_='123456')
     orig_nvr = 'e2e-container-test-product-container-7.3-210.1523551880'
     assert build is not None
     assert build.original_nvr == orig_nvr
+    assert build.name == 'e2e-container-test-product-container'
+    assert build.release == '37.1528968216'
+    assert build.version == '8.4'
     assert event.triggered_container_builds.is_connected(build)
     assert build.state == 0
-    build = ContainerKojiBuild.nodes.get_or_none(id_=234567)
+    build = ContainerKojiBuild.nodes.get_or_none(id_='234567')
     orig_nvr = 'e2e-container-test-product-container-7.4-36'
     assert build is not None
     assert build.original_nvr == orig_nvr
+    assert build.name == 'e2e-container-test-product-container'
+    assert build.release == '38.1528968216'
+    assert build.version == '9.4'
     assert event.triggered_container_builds.is_connected(build)
     assert build.state == 0
 
 
 @mock.patch('koji.ClientSession')
-def test_event_to_complete(mock_koji_cs):
+def test_event_to_complete(mock_koji_cs, mock_build_one, mock_build_two, mock_build_three):
     """Test the Freshmaker handler when it receives an event to complete message."""
     mock_koji_session = mock.Mock()
     mock_koji_session.getTaskResult.side_effect = [
@@ -93,6 +105,10 @@ def test_event_to_complete(mock_koji_cs):
             'koji_builds': ['234567']
         }
     ]
+    mock_build_one['state'] = 3
+    mock_build_two['state'] = 3
+    mock_build_three['state'] = 1
+    mock_koji_session.getBuild.side_effect = [mock_build_one, mock_build_two, mock_build_three]
     mock_koji_cs.return_value = mock_koji_session
     event = FreshmakerEvent.get_or_create({
         'id_': '2194',
@@ -103,19 +119,49 @@ def test_event_to_complete(mock_koji_cs):
             'ID:messaging.domain.com-42045-1527890187852-9:1045742:0:0:1.RHBA-8018:0600-01'
     })[0]
     ContainerKojiBuild.get_or_create({
-        'id_': 710916,
+        'completion_time': datetime(2018, 6, 15, 20, 26, 38, tzinfo=pytz.utc),
+        'creation_time': datetime(2018, 6, 15, 20, 20, 38, tzinfo=pytz.utc),
+        'epoch': 'epoch',
+        'extra': '{"container_koji_task_id": 17511743}',
+        'id_': '710916',
+        'name': 'e2e-container-test-product-container',
+        'package_name': 'openstack-zaqar-container',
         'original_nvr': 'e2e-container-test-product-container-7.3-210.1523551880',
-        'state': 3
+        'owner_name': 'emusk',
+        'release': '36.1528968216',
+        'start_time': datetime(2018, 6, 15, 20, 21, 38, tzinfo=pytz.utc),
+        'state': 3,
+        'version': '7.4'
     })[0].triggered_by_freshmaker_event.connect(event)
     ContainerKojiBuild.get_or_create({
-        'id_': 123456,
-        'original_nvr': 'e2e-container-test-product-container-7.4-36',
-        'state': 3
+        'completion_time': datetime(2018, 6, 15, 20, 26, 38, tzinfo=pytz.utc),
+        'creation_time': datetime(2018, 6, 15, 20, 20, 38, tzinfo=pytz.utc),
+        'epoch': 'epoch',
+        'extra': '{"container_koji_task_id": 123456}',
+        'id_': '123456',
+        'name': 'e2e-container-test-product-container',
+        'package_name': 'openstack-zaqar-container',
+        'original_nvr': 'e2e-container-test-product-container-7.3-210.1523551880',
+        'owner_name': 'emusk',
+        'release': '37.1528968216',
+        'start_time': datetime(2018, 6, 15, 20, 21, 38, tzinfo=pytz.utc),
+        'state': 3,
+        'version': '8.4'
     })[0].triggered_by_freshmaker_event.connect(event)
     ContainerKojiBuild.get_or_create({
-        'id_': 234567,
-        'original_nvr': 'e2e-container-test-product-container-7.5-133',
-        'state': 1
+        'completion_time': datetime(2018, 6, 15, 20, 26, 38, tzinfo=pytz.utc),
+        'creation_time': datetime(2018, 6, 15, 20, 20, 38, tzinfo=pytz.utc),
+        'epoch': 'epoch',
+        'extra': '{"container_koji_task_id": 234567 }',
+        'id_': '234567',
+        'name': 'e2e-container-test-product-container',
+        'package_name': 'openstack-zaqar-container',
+        'original_nvr': 'e2e-container-test-product-container-7.3-210.1523551880',
+        'owner_name': 'emusk',
+        'release': '38.1528968216',
+        'start_time': datetime(2018, 6, 15, 20, 21, 38, tzinfo=pytz.utc),
+        'state': 1,
+        'version': '9.4'
     })[0].triggered_by_freshmaker_event.connect(event)
     # Load the message to pass to the handler
     with open(path.join(message_dir, 'freshmaker', 'event_to_complete.json'), 'r') as f:
@@ -136,35 +182,21 @@ def test_event_to_complete(mock_koji_cs):
     assert event.state_name == 'COMPLETE'
     assert event.state_reason == '2 of 3 container image(s) failed to rebuild.'
 
-    build = ContainerKojiBuild.nodes.get_or_none(id_=710916)
-    orig_nvr = 'e2e-container-test-product-container-7.3-210.1523551880'
-    assert build is not None
-    assert build.original_nvr == orig_nvr
+    build = ContainerKojiBuild.nodes.get_or_none(id_='710916')
     assert build.state == 3
-    assert event.triggered_container_builds.is_connected(build)
-    build = ContainerKojiBuild.nodes.get_or_none(id_=123456)
-    orig_nvr = 'e2e-container-test-product-container-7.4-36'
-    assert build is not None
-    assert build.original_nvr == orig_nvr
+    build = ContainerKojiBuild.nodes.get_or_none(id_='123456')
     assert build.state == 3
-    assert event.triggered_container_builds.is_connected(build)
-    build = ContainerKojiBuild.nodes.get_or_none(id_=234567)
-    orig_nvr = 'e2e-container-test-product-container-7.5-133'
-    assert build is not None
-    assert build.original_nvr == orig_nvr
+    build = ContainerKojiBuild.nodes.get_or_none(id_='234567')
     assert build.state == 1
-    assert event.triggered_container_builds.is_connected(build)
 
 
 @mock.patch('koji.ClientSession')
-def test_build_state_change(mock_koji_cs):
+def test_build_state_change(mock_koji_cs, mock_build_one):
     """Test the Freshmaker handler when it receives a build state change message."""
     mock_koji_session = mock.Mock()
-    mock_koji_session.getTaskResult.side_effect = [
-        {
-            'koji_builds': ['710916']
-        }
-    ]
+    mock_koji_session.getTaskResult.return_value = {'koji_builds': ['710916']}
+    mock_build_one['state'] = 1
+    mock_koji_session.getBuild.return_value = mock_build_one
     mock_koji_cs.return_value = mock_koji_session
     event = FreshmakerEvent.get_or_create({
         'id_': '2094',
@@ -174,9 +206,19 @@ def test_build_state_change(mock_koji_cs):
         'message_id': 'ID:messaging.domain.com-42045-1527890187852-9:704208:0:0:1.RHBA-8018:0593-01'
     })[0]
     build = ContainerKojiBuild.create_or_update({
+        'completion_time': datetime(2018, 6, 15, 20, 26, 38, tzinfo=pytz.utc),
+        'creation_time': datetime(2018, 6, 15, 20, 20, 38, tzinfo=pytz.utc),
+        'epoch': 'epoch',
+        'extra': '{"container_koji_task_id": 17511743}',
         'id_': '710916',
-        'original_nvr': 'logging-kibana-container-v3.9.30-3',
-        'state': 0
+        'name': 'e2e-container-test-product-container',
+        'package_name': 'openstack-zaqar-container',
+        'original_nvr': 'e2e-container-test-product-container-7.3-210.1523551880',
+        'owner_name': 'emusk',
+        'release': '36.1528968216',
+        'start_time': datetime(2018, 6, 15, 20, 21, 38, tzinfo=pytz.utc),
+        'state': 0,
+        'version': '7.4'
     })[0]
     event.triggered_container_builds.connect(build)
     # Load the message to pass to the handler
@@ -189,8 +231,4 @@ def test_build_state_change(mock_koji_cs):
     # Run the handler
     handler.handle(msg)
 
-    build = ContainerKojiBuild.nodes.get_or_none(id_=710916)
-    orig_nvr = 'logging-kibana-container-v3.9.30-3'
-    assert build is not None
-    assert build.original_nvr == orig_nvr
-    assert build.state == 1
+    assert ContainerKojiBuild.nodes.get_or_none(id_='710916').state == 1

--- a/tests/messages/errata/builds_added.json
+++ b/tests/messages/errata/builds_added.json
@@ -18,7 +18,7 @@
             "release": "OpenStack 13.0.z for RHEL 7", 
             "JMS_AMQP_FirstAcquirer": "false", 
             "type": "errata.builds.added", 
-            "brew_build": "openstack-zaqar-container-13.0-45"
+            "brew_build": "e2e-container-test-product-container-7.4-36.1528968216"
         },
         "msg":{
             "product": "RHOS", 
@@ -29,7 +29,7 @@
             "RHEL-7-OS-13"
             ], 
             "release": "OpenStack 13.0.z for RHEL 7", 
-            "brew_build": "openstack-zaqar-container-13.0-45"
+            "brew_build": "e2e-container-test-product-container-7.4-36.1528968216"
         }  
     },
     "topic":"/topic/VirtualTopic.eng.errata.builds.added",
@@ -51,6 +51,6 @@
         "release": "OpenStack 13.0.z for RHEL 7", 
         "JMS_AMQP_FirstAcquirer": "false", 
         "type": "errata.builds.added", 
-        "brew_build": "openstack-zaqar-container-13.0-45"
+        "brew_build": "e2e-container-test-product-container-7.4-36.1528968216"
     }
 }

--- a/tests/messages/errata/builds_removed.json
+++ b/tests/messages/errata/builds_removed.json
@@ -18,7 +18,7 @@
             "release": "RHOSE ASYNC",
             "JMS_AMQP_FirstAcquirer": "false",
             "type": "errata.builds.removed",
-            "brew_build": "openstack-zaqar-container-13.0-45"
+            "brew_build": "e2e-container-test-product-container-7.4-36.1528968216"
         },
         "msg": {
             "product": "RHOSE",
@@ -29,7 +29,7 @@
                 "RHEL-7-OSE-3.10"
             ],
             "release": "RHOSE ASYNC",
-            "brew_build": "openstack-zaqar-container-13.0-45"
+            "brew_build": "e2e-container-test-product-container-7.4-36.1528968216"
         }
     },
     "topic": "/topic/VirtualTopic.eng.errata.builds.removed",
@@ -51,6 +51,6 @@
         "release": "RHOSE ASYNC",
         "JMS_AMQP_FirstAcquirer": "false",
         "type": "errata.builds.removed",
-        "brew_build": "openstack-zaqar-container-13.0-45"
+        "brew_build": "e2e-container-test-product-container-7.4-36.1528968216"
     }
 }


### PR DESCRIPTION
This PR makes it so that container builds in Neo4j have all their properties filled out. Additionally, I've moved some code that created builds from the Errata Tool handler to the base class and made it dynamically determine if the build is a container or not when creating it. 

I've also added some clarifying comments and a small change to a docstring in separate commits.