### PR TITLE
Only query Koji on done Freshmaker builds

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -8,6 +8,7 @@ import pytest
 from neomodel import config as neomodel_config, db as neo4j_db
 from estuary.models.koji import ContainerKojiBuild
 import pytz
+import koji
 
 from estuary_updater.consumer import EstuaryUpdater
 
@@ -50,7 +51,7 @@ def mock_getBuild_one():
         'release': '36.1528968216',
         'version': '7.4',
         'start_ts': 1529094098.0,
-        'state': 0
+        'state': koji.BUILD_STATES['COMPLETE']
     }
 
 
@@ -71,82 +72,4 @@ def cb_one():
         'start_time': datetime(2018, 6, 15, 20, 21, 38, tzinfo=pytz.utc),
         'state': 3,
         'version': '7.4'
-    })[0]
-
-
-@pytest.fixture
-def mock_getBuild_two():
-    """Return a mock build in the format of koji.ClientSession.getBuild."""
-    return {
-        'completion_ts': 1529094398.0,
-        'creation_ts': 1529094038.0,
-        'epoch': 'epoch',
-        'extra': {'container_koji_task_id': 17511743},
-        'id': 123456,
-        'name': 'e2e-container-test-product-container',
-        'package_name': 'e2e-container-test-product-container',
-        'owner_name': 'emusk',
-        'release': '37.1528968216',
-        'version': '8.4',
-        'start_ts': 1529094098.0,
-        'state': 0
-    }
-
-
-@pytest.fixture
-def cb_two():
-    """Return a KojiContainerBuild matching mock_getBuild_two."""
-    return ContainerKojiBuild.get_or_create({
-        'completion_time': datetime(2018, 6, 15, 20, 26, 38, tzinfo=pytz.utc),
-        'creation_time': datetime(2018, 6, 15, 20, 20, 38, tzinfo=pytz.utc),
-        'epoch': 'epoch',
-        'extra': '{"container_koji_task_id": 123456}',
-        'id_': '123456',
-        'name': 'e2e-container-test-product-container',
-        'package_name': 'openstack-zaqar-container',
-        'original_nvr': 'e2e-container-test-product-container-7.3-210.1523551880',
-        'owner_name': 'emusk',
-        'release': '37.1528968216',
-        'start_time': datetime(2018, 6, 15, 20, 21, 38, tzinfo=pytz.utc),
-        'state': 3,
-        'version': '8.4'
-    })[0]
-
-
-@pytest.fixture
-def mock_getBuild_three():
-    """Return a mock build in the format of koji.ClientSession.getBuild."""
-    return {
-        'completion_ts': 1529094398.0,
-        'creation_ts': 1529094038.0,
-        'epoch': 'epoch',
-        'extra': {'container_koji_task_id': 17511743},
-        'id': 234567,
-        'name': 'e2e-container-test-product-container',
-        'package_name': 'e2e-container-test-product-container',
-        'owner_name': 'emusk',
-        'release': '38.1528968216',
-        'version': '9.4',
-        'start_ts': 1529094098.0,
-        'state': 0
-    }
-
-
-@pytest.fixture
-def cb_three():
-    """Return a KojiContainerBuild matching mock_getBuild_three."""
-    return ContainerKojiBuild.get_or_create({
-        'completion_time': datetime(2018, 6, 15, 20, 26, 38, tzinfo=pytz.utc),
-        'creation_time': datetime(2018, 6, 15, 20, 20, 38, tzinfo=pytz.utc),
-        'epoch': 'epoch',
-        'extra': '{"container_koji_task_id": 234567 }',
-        'id_': '234567',
-        'name': 'e2e-container-test-product-container',
-        'package_name': 'openstack-zaqar-container',
-        'original_nvr': 'e2e-container-test-product-container-7.3-210.1523551880',
-        'owner_name': 'emusk',
-        'release': '38.1528968216',
-        'start_time': datetime(2018, 6, 15, 20, 21, 38, tzinfo=pytz.utc),
-        'state': 1,
-        'version': '9.4'
     })[0]

--- a/tests/handlers/test_freshmaker.py
+++ b/tests/handlers/test_freshmaker.py
@@ -17,24 +17,8 @@ from estuary_updater.handlers.freshmaker import FreshmakerHandler
 from estuary_updater import config
 
 
-@mock.patch('koji.ClientSession')
-def test_event_to_building(mock_koji_cs, mock_getBuild_one, mock_getBuild_two, mock_getBuild_three):
+def test_event_to_building():
     """Test the Freshmaker handler when it receives an event to building message."""
-    mock_koji_session = mock.Mock()
-    mock_koji_session.getTaskResult.side_effect = [
-        {
-            'koji_builds': ['710916']
-        },
-        {
-            'koji_builds': ['123456']
-        },
-        {
-            'koji_builds': ['234567']
-        }
-    ]
-    mock_koji_session.getBuild.side_effect = [
-        mock_getBuild_one, mock_getBuild_two, mock_getBuild_three]
-    mock_koji_cs.return_value = mock_koji_session
     # Load the message to pass to the handler
     with open(path.join(message_dir, 'freshmaker', 'event_to_building.json'), 'r') as f:
         msg = json.load(f)
@@ -47,8 +31,6 @@ def test_event_to_building(mock_koji_cs, mock_getBuild_one, mock_getBuild_two, m
 
     event = FreshmakerEvent.nodes.get_or_none(id_='2092')
     assert event is not None
-
-    # Check to see if properties are correct
     assert event.id_ == '2092'
     assert event.event_type_id == 8
     assert event.message_id == \
@@ -61,66 +43,13 @@ def test_event_to_building(mock_koji_cs, mock_getBuild_one, mock_getBuild_two, m
     advisory = Advisory.nodes.get_or_none(id_='34625')
     assert advisory is not None
     assert event.triggered_by_advisory.is_connected(advisory)
-
-    params = (
-        {
-            'id_': '710916',
-            'original_nvr': 'e2e-container-test-product-container-7.5-129',
-            'release': '36.1528968216',
-            'version': '7.4'
-        },
-        {
-            'id_': '123456',
-            'original_nvr': 'e2e-container-test-product-container-7.3-210.1523551880',
-            'release': '37.1528968216',
-            'version': '8.4'
-        },
-        {
-            'id_': '234567',
-            'original_nvr': 'e2e-container-test-product-container-7.4-36',
-            'release': '38.1528968216',
-            'version': '9.4'
-        }
-    )
-    for param in params:
-        build = ContainerKojiBuild.nodes.get_or_none(id_=param['id_'])
-        assert build is not None
-        assert build.completion_time == datetime(2018, 6, 15, 20, 26, 38, tzinfo=pytz.utc)
-        assert build.creation_time == datetime(2018, 6, 15, 20, 20, 38, tzinfo=pytz.utc)
-        assert build.epoch == 'epoch'
-        assert build.extra == '{"container_koji_task_id": 17511743}'
-        assert build.id_ == param['id_']
-        assert build.name == 'e2e-container-test-product-container'
-        assert build.original_nvr == param['original_nvr']
-        assert build.release == param['release']
-        assert build.version == param['version']
-        assert build.start_time == datetime(2018, 6, 15, 20, 21, 38, tzinfo=pytz.utc)
-        assert build.state == 0
-        assert event.triggered_container_builds.is_connected(build)
+    # No container builds should be attached since the builds in Koji only exist after the
+    # build task Freshmaker tracks is complete
+    assert len(event.triggered_container_builds) == 0
 
 
-@mock.patch('koji.ClientSession')
-def test_event_to_complete(mock_koji_cs, mock_getBuild_one, mock_getBuild_two, mock_getBuild_three,
-                           cb_one, cb_two, cb_three):
+def test_event_to_complete(cb_one):
     """Test the Freshmaker handler when it receives an event to complete message."""
-    mock_koji_session = mock.Mock()
-    mock_koji_session.getTaskResult.side_effect = [
-        {
-            'koji_builds': ['710916']
-        },
-        {
-            'koji_builds': ['123456']
-        },
-        {
-            'koji_builds': ['234567']
-        }
-    ]
-    mock_getBuild_one['state'] = 3
-    mock_getBuild_two['state'] = 3
-    mock_getBuild_three['state'] = 1
-    mock_koji_session.getBuild.side_effect = [
-        mock_getBuild_one, mock_getBuild_two, mock_getBuild_three]
-    mock_koji_cs.return_value = mock_koji_session
     event = FreshmakerEvent.get_or_create({
         'id_': '2194',
         'state': 1,
@@ -129,9 +58,7 @@ def test_event_to_complete(mock_koji_cs, mock_getBuild_one, mock_getBuild_two, m
         'message_id':
             'ID:messaging.domain.com-42045-1527890187852-9:1045742:0:0:1.RHBA-8018:0600-01'
     })[0]
-    cb_one.triggered_by_freshmaker_event.connect(event)
-    cb_two.triggered_by_freshmaker_event.connect(event)
-    cb_three.triggered_by_freshmaker_event.connect(event)
+    event.triggered_container_builds.connect(cb_one)
     # Load the message to pass to the handler
     with open(path.join(message_dir, 'freshmaker', 'event_to_complete.json'), 'r') as f:
         msg = json.load(f)
@@ -150,31 +77,23 @@ def test_event_to_complete(mock_koji_cs, mock_getBuild_one, mock_getBuild_two, m
     assert event.state == 2
     assert event.state_name == 'COMPLETE'
     assert event.state_reason == '2 of 3 container image(s) failed to rebuild.'
-
-    build = ContainerKojiBuild.nodes.get_or_none(id_='710916')
-    assert build.state == 3
-    build = ContainerKojiBuild.nodes.get_or_none(id_='123456')
-    assert build.state == 3
-    build = ContainerKojiBuild.nodes.get_or_none(id_='234567')
-    assert build.state == 1
+    assert len(event.triggered_container_builds) == 1
 
 
 @mock.patch('koji.ClientSession')
-def test_build_state_change(mock_koji_cs, mock_getBuild_one, cb_one):
+def test_build_state_change(mock_koji_cs, mock_getBuild_one):
     """Test the Freshmaker handler when it receives a build state change message."""
     mock_koji_session = mock.Mock()
     mock_koji_session.getTaskResult.return_value = {'koji_builds': ['710916']}
-    mock_getBuild_one['state'] = 1
     mock_koji_session.getBuild.return_value = mock_getBuild_one
     mock_koji_cs.return_value = mock_koji_session
     event = FreshmakerEvent.get_or_create({
-        'id_': '2094',
+        'id_': '1260',
         'state': 1,
         'state_name': 'BUILDING',
         'event_type_id': 8,
         'message_id': 'ID:messaging.domain.com-42045-1527890187852-9:704208:0:0:1.RHBA-8018:0593-01'
     })[0]
-    event.triggered_container_builds.connect(cb_one)
     # Load the message to pass to the handler
     with open(path.join(message_dir, 'freshmaker', 'build_state_change.json'), 'r') as f:
         msg = json.load(f)
@@ -185,4 +104,23 @@ def test_build_state_change(mock_koji_cs, mock_getBuild_one, cb_one):
     # Run the handler
     handler.handle(msg)
 
-    assert ContainerKojiBuild.nodes.get_or_none(id_='710916').state == 1
+    build = ContainerKojiBuild.nodes.get_or_none(id_='710916')
+    assert build is not None
+    assert build.completion_time == datetime(2018, 6, 15, 20, 26, 38, tzinfo=pytz.utc)
+    assert build.creation_time == datetime(2018, 6, 15, 20, 20, 38, tzinfo=pytz.utc)
+    assert build.epoch == 'epoch'
+    assert build.extra == '{"container_koji_task_id": 17511743}'
+    assert build.id_ == '710916'
+    assert build.name == 'e2e-container-test-product-container'
+    assert build.original_nvr == 'e2e-container-test-product-container-7.5-133'
+    assert build.release == '36.1528968216'
+    assert build.version == '7.4'
+    assert build.start_time == datetime(2018, 6, 15, 20, 21, 38, tzinfo=pytz.utc)
+    assert build.state == 1
+    assert build.triggered_by_freshmaker_event.is_connected(event)
+
+    assert event.triggered_container_builds.is_connected(build)
+    assert len(event.triggered_container_builds) == 1
+
+    mock_koji_session.getTaskResult.assert_called_once_with(16735050)
+    mock_koji_session.getBuild.assert_called_once_with(710916, strict=True)

--- a/tests/messages/freshmaker/build_state_change.json
+++ b/tests/messages/freshmaker/build_state_change.json
@@ -16,10 +16,10 @@
             "build_id": 16735050, 
             "state_reason": "Built successfully.", 
             "time_completed": "2018-06-14T23:50:37Z", 
-            "name": "logging-kibana-container", 
+            "name": "e2e-container-test-product-container", 
             "time_submitted": "2018-06-14T20:26:06Z", 
             "event_id": 2094, 
-            "original_nvr": "logging-kibana-container-v3.9.30-3", 
+            "original_nvr": "e2e-container-test-product-container-7.5-133", 
             "type_name": "IMAGE", 
             "state_name": "DONE", 
             "url": "http://freshmaker.domain.com/api/1/builds/1260", 
@@ -34,7 +34,7 @@
             "dep_on": "rh-nodejs6-docker", 
             "type": 1, 
             "id": 1260, 
-            "rebuilt_nvr": "logging-kibana-container-v3.9.30-3.1529007966"
+            "rebuilt_nvr": "e2e-container-test-product-container-7.4-36.1528968216"
         }
     },
     "topic":"/topic/VirtualTopic.eng.freshmaker.build.state.changed",


### PR DESCRIPTION
Freshmaker builds track the state of a Koji task that is kicked off by OSBS. This task is what actually creates the build entry for the container image in Koji. Since the Koji build will not exist until the task is complete, we can avoid querying Koji until the Freshmaker build is complete.

Additionally, since we create the build entries on build state change messages, we no longer need to create and connect builds on event state change messages. This should increase performance on Freshmaker events with large amounts of builds.