### PR TITLE
Add the Errata and Koji handlers to all_handlers

### DIFF
--- a/estuary_updater/handlers/__init__.py
+++ b/estuary_updater/handlers/__init__.py
@@ -4,7 +4,9 @@ from __future__ import unicode_literals, absolute_import
 
 from estuary_updater.handlers.freshmaker import FreshmakerHandler
 from estuary_updater.handlers.distgit import DistGitHandler
+from estuary_updater.handlers.errata import ErrataHandler
+from estuary_updater.handlers.koji import KojiHandler
 
 
 # All handler classes are added here
-all_handlers = [FreshmakerHandler, DistGitHandler]
+all_handlers = [DistGitHandler, FreshmakerHandler, ErrataHandler, KojiHandler]


### PR DESCRIPTION
The Errata handler and Koji handler can't run until they are in the `all_handlers` list because the code in `consumer.py` can't find the proper handler to handle those types of messages.