### PR TITLE
Use conditional connect to avoid cardinality violations

### DIFF
--- a/estuary_updater/handlers/base.py
+++ b/estuary_updater/handlers/base.py
@@ -134,6 +134,6 @@ class BaseHandler(object):
         else:
             koji_build = KojiBuild.create_or_update(build_params)[0]
 
-        koji_build.owner.connect(owner)
+        koji_build.conditional_connect(koji_build.owner, owner)
 
         return koji_build

--- a/estuary_updater/handlers/errata.py
+++ b/estuary_updater/handlers/errata.py
@@ -137,8 +137,8 @@ class ErrataHandler(BaseHandler):
                 container_adv.remove_label(ContainerAdvisory.__label__)
             advisory = Advisory.create_or_update(advisory_params)[0]
 
-        advisory.reporter.connect(reporter)
-        advisory.assigned_to.connect(assigned_to)
+        advisory.conditional_connect(advisory.reporter, reporter)
+        advisory.conditional_connect(advisory.assigned_to, assigned_to)
 
         bugs = advisory_json['bugs']['bugs']
 


### PR DESCRIPTION
Since relationships like `owner` have a cardinality of `ZeroOrOne`, we cannot just connect another user when the user changes. We need to replace the relationship, so that is what `conditional_connect` solves here.