### PR TITLE
Fix the log formatting

### DIFF
--- a/estuary_updater/__init__.py
+++ b/estuary_updater/__init__.py
@@ -9,7 +9,7 @@ import fedmsg.config
 
 
 config = fedmsg.config.load_config()
-logging.basicConfig(format='%(asctime) [%(filename)s:%(lineno)s:%(funcName)s] %(message)s')
+logging.basicConfig(format='%(asctime)s [%(filename)s:%(lineno)s:%(funcName)s] %(message)s')
 log = logging.getLogger('estuary_updater')
 log.setLevel(config.get('estuary_updater.log_level', logging.INFO))
 

--- a/estuary_updater/__init__.py
+++ b/estuary_updater/__init__.py
@@ -9,7 +9,8 @@ import fedmsg.config
 
 
 config = fedmsg.config.load_config()
-logging.basicConfig(format='%(asctime)s [%(filename)s:%(lineno)s:%(funcName)s] %(message)s')
+logging.basicConfig(
+    format='%(asctime)s - %(filename)s:%(lineno)s:%(funcName)s - %(levelname)s: %(message)s')
 log = logging.getLogger('estuary_updater')
 log.setLevel(config.get('estuary_updater.log_level', logging.INFO))
 


### PR DESCRIPTION
The first commit resolves a syntax error and the second commit adds the log level in the format.