### PR TITLE
Reduce some of the noise in the debug logs

### DIFF
--- a/estuary_updater/consumer.py
+++ b/estuary_updater/consumer.py
@@ -29,10 +29,10 @@ class EstuaryUpdater(fedmsg.consumers.FedmsgConsumer):
         for handler_cls in all_handlers:
             if handler_cls.can_handle(msg):
                 log.debug('The handler {0} supports handling the message: {1}'.format(
-                    handler_cls.__name__, msg))
+                    handler_cls.__name__, msg['headers']['message-id']))
                 handler = handler_cls(config)
                 log.debug('The handler {0} is instantiated and will handle the message: {1}'.format(
-                    handler_cls.__name__, msg))
+                    handler_cls.__name__, msg['headers']['message-id']))
                 handler.handle(msg)
                 log.debug('The handler {0} is done handling the message: {1}'.format(
-                    handler_cls.__name__, msg))
+                    handler_cls.__name__, msg['headers']['message-id']))


### PR DESCRIPTION
Instead of logging the whole message, let's just log the message ID. If we need to retrieve the actual message, we can query datagrepper using the message ID. This will make the logs a lot more readable.