### PR TITLE
Revert "Use the Koji *_time values instead of *_ts"

### DIFF
--- a/estuary_updater/handlers/base.py
+++ b/estuary_updater/handlers/base.py
@@ -132,12 +132,11 @@ class BaseHandler(object):
             build_params['extra'] = json.dumps(build_info['extra'])
 
         # To handle the case when a message has a null timestamp
-        for time_key in ('completion_time', 'creation_time', 'start_time'):
-            # Certain Koji API endpoints omit the *_ts values but have the *_time values, so that's
-            # why the *_time values are used
-            if build_info[time_key]:
-                build_params[time_key] = datetime.strptime(
-                    build_info[time_key], '%Y-%m-%d %H:%M:%S.%f')
+        for ts in ('completion_ts', 'creation_ts', 'start_ts'):
+            # Remove last 2 characters and append 'time' to get key in build_params
+            dict_key = ts[:-2] + 'time'
+            if build_info[ts]:
+                build_params[dict_key] = datetime.fromtimestamp(int(build_info[ts]))
 
         owner = User.create_or_update({
             'username': build_info['owner_name'],

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -40,9 +40,7 @@ def consumer():
 def mock_getBuild_one():
     """Return a mock build in the format of koji.ClientSession.getBuild."""
     return {
-        'completion_time': '2018-06-15 16:26:38.000000',
         'completion_ts': 1529094398.0,
-        'creation_time': '2018-06-15 16:20:38.000000',
         'creation_ts': 1529094038.0,
         'epoch': 'epoch',
         'extra': {'container_koji_task_id': 17511743},
@@ -52,7 +50,6 @@ def mock_getBuild_one():
         'owner_name': 'emusk',
         'release': '36.1528968216',
         'version': '7.4',
-        'start_time': '2018-06-15 16:21:38.000000',
         'start_ts': 1529094098.0,
         'state': koji.BUILD_STATES['COMPLETE']
     }
@@ -62,9 +59,7 @@ def mock_getBuild_one():
 def mock_getBuild_complete():
     """Return a mock build in the format of koji.ClientSession.getBuild."""
     return {
-        'completion_time': '2018-06-15 16:26:38.000000',
         'completion_ts': 1529094398.0,
-        'creation_time': '2018-08-03 13:49:42.735510',
         'creation_ts': 1533318582.73551,
         'epoch': None,
         'extra': {"source": {"original_url": "git://pkgs.domain.com/rpms/python-attrs?#3be3cb33e64"
@@ -76,7 +71,6 @@ def mock_getBuild_complete():
         'release': '8.el8+1325+72a36e76',
         'version': '17.4.0',
         'start_ts': 1533318582.73551,
-        'start_time': '2018-08-03 13:49:42.735510',
         'state': koji.BUILD_STATES['COMPLETE']
     }
 
@@ -85,9 +79,7 @@ def mock_getBuild_complete():
 def mock_getBuild_module_complete():
     """Return a mock build in the format of koji.ClientSession.getBuild."""
     return {
-        'completion_time': '2018-08-17 12:54:17.000000',
         'completion_ts': 1534524857.0,
-        'creation_time': '2018-08-17 12:54:29.130570',
         'creation_ts': 1534524869.13057,
         'epoch': None,
         'extra': {
@@ -109,7 +101,6 @@ def mock_getBuild_module_complete():
         'owner_name': 'emusk',
         'release': '20180817161005.9edba152',
         'version': 'rhel',
-        'start_time': '2018-08-17 12:10:29.000000',
         'start_ts': 1534522229.0,
         'state': koji.BUILD_STATES['COMPLETE']
     }

--- a/tests/handlers/test_errata.py
+++ b/tests/handlers/test_errata.py
@@ -134,12 +134,12 @@ def test_builds_added_handler(mock_koji_cs, mock_getBuild_one):
     assert build.name == 'e2e-container-test-product-container'
     assert build.version == '7.4'
     assert build.release == '36.1528968216'
-    assert build.completion_time == datetime.datetime(2018, 6, 15, 16, 26, 38, tzinfo=pytz.utc)
-    assert build.creation_time == datetime.datetime(2018, 6, 15, 16, 20, 38, tzinfo=pytz.utc)
+    assert build.completion_time == datetime.datetime(2018, 6, 15, 20, 26, 38, tzinfo=pytz.utc)
+    assert build.creation_time == datetime.datetime(2018, 6, 15, 20, 20, 38, tzinfo=pytz.utc)
     assert build.epoch == 'epoch'
     assert build.extra == '{"container_koji_task_id": 17511743}'
     assert build.id_ == '710916'
-    assert build.start_time == datetime.datetime(2018, 6, 15, 16, 21, 38, tzinfo=pytz.utc)
+    assert build.start_time == datetime.datetime(2018, 6, 15, 20, 21, 38, tzinfo=pytz.utc)
     assert build.state == 1
 
     assert advisory.attached_builds.is_connected(build)

--- a/tests/handlers/test_freshmaker.py
+++ b/tests/handlers/test_freshmaker.py
@@ -112,8 +112,8 @@ def test_build_state_change(mock_koji_cs, mock_getBuild_one):
 
     build = ContainerKojiBuild.nodes.get_or_none(id_='710916')
     assert build is not None
-    assert build.completion_time == datetime(2018, 6, 15, 16, 26, 38, tzinfo=pytz.utc)
-    assert build.creation_time == datetime(2018, 6, 15, 16, 20, 38, tzinfo=pytz.utc)
+    assert build.completion_time == datetime(2018, 6, 15, 20, 26, 38, tzinfo=pytz.utc)
+    assert build.creation_time == datetime(2018, 6, 15, 20, 20, 38, tzinfo=pytz.utc)
     assert build.epoch == 'epoch'
     assert build.extra == '{"container_koji_task_id": 17511743}'
     assert build.id_ == '710916'
@@ -121,7 +121,7 @@ def test_build_state_change(mock_koji_cs, mock_getBuild_one):
     assert build.original_nvr == 'e2e-container-test-product-container-7.5-133'
     assert build.release == '36.1528968216'
     assert build.version == '7.4'
-    assert build.start_time == datetime(2018, 6, 15, 16, 21, 38, tzinfo=pytz.utc)
+    assert build.start_time == datetime(2018, 6, 15, 20, 21, 38, tzinfo=pytz.utc)
     assert build.state == 1
     assert build.triggered_by_freshmaker_event.is_connected(event)
 

--- a/tests/handlers/test_koji.py
+++ b/tests/handlers/test_koji.py
@@ -31,8 +31,8 @@ def test_build_complete(mock_koji_cs, mock_getBuild_complete):
 
     build = KojiBuild.nodes.get_or_none(id_='736244')
     assert build is not None
-    assert build.completion_time == datetime(2018, 6, 15, 16, 26, 38, tzinfo=pytz.utc)
-    assert build.creation_time == datetime(2018, 8, 3, 13, 49, 42, 735510, tzinfo=pytz.utc)
+    assert build.completion_time == datetime(2018, 6, 15, 20, 26, 38, tzinfo=pytz.utc)
+    assert build.creation_time == datetime(2018, 8, 3, 17, 49, 42, tzinfo=pytz.utc)
     assert build.epoch is None
     assert build.extra == ('{"source": {"original_url": "git://pkgs.domain.com/rpms/python-'
                            'attrs?#3be3cb33e6432d8392ac3d9e6edffd990f618432"}}')
@@ -40,7 +40,7 @@ def test_build_complete(mock_koji_cs, mock_getBuild_complete):
     assert build.name == 'python-attrs'
     assert build.release == '8.el8+1325+72a36e76'
     assert build.version == '17.4.0'
-    assert build.start_time == datetime(2018, 8, 3, 13, 49, 42, 735510, tzinfo=pytz.utc)
+    assert build.start_time == datetime(2018, 8, 3, 17, 49, 42, tzinfo=pytz.utc)
     assert build.state == 1
 
     commit = DistGitCommit.nodes.get_or_none(hash_='3be3cb33e6432d8392ac3d9e6edffd990f618432')
@@ -55,10 +55,6 @@ def test_modulebuild_complete(mock_koji_cs, mock_getBuild_module_complete,
     mock_koji_session = mock.Mock()
     mock_koji_session.getBuild.return_value = mock_getBuild_module_complete
     mock_koji_session.getTag.return_value = module_build_getTag
-    # These values are present from the return value of getBuild but not listTaggedRPMS
-    del mock_getBuild_complete['completion_ts']
-    del mock_getBuild_complete['creation_ts']
-    del mock_getBuild_complete['start_ts']
     mock_koji_session.listTaggedRPMS.return_value = [[], [mock_getBuild_complete]]
     mock_koji_cs.return_value = mock_koji_session
 
@@ -71,8 +67,8 @@ def test_modulebuild_complete(mock_koji_cs, mock_getBuild_module_complete,
     build = ModuleKojiBuild.nodes.get_or_none(id_='753795')
     # Regular Koji Build attributes
     assert build is not None
-    assert build.completion_time == datetime(2018, 8, 17, 12, 54, 17, tzinfo=pytz.utc)
-    assert build.creation_time == datetime(2018, 8, 17, 12, 54, 29, 130570, tzinfo=pytz.utc)
+    assert build.completion_time == datetime(2018, 8, 17, 16, 54, 17, tzinfo=pytz.utc)
+    assert build.creation_time == datetime(2018, 8, 17, 16, 54, 29, tzinfo=pytz.utc)
     assert build.epoch is None
     assert build.extra == ('{"typeinfo": {"module": {"modulemd_str": "module", "name": "virt",'
                            ' "stream": "rhel", "module_build_service_id": 1648, '
@@ -82,7 +78,7 @@ def test_modulebuild_complete(mock_koji_cs, mock_getBuild_module_complete,
     assert build.name == 'virt'
     assert build.release == '20180817161005.9edba152'
     assert build.version == 'rhel'
-    assert build.start_time == datetime(2018, 8, 17, 12, 10, 29, tzinfo=pytz.utc)
+    assert build.start_time == datetime(2018, 8, 17, 16, 10, 29, tzinfo=pytz.utc)
     assert build.state == 1
     # Additional Module Koji Build attributes
     assert build.context == '9edba152'


### PR DESCRIPTION
Reverts release-engineering/estuary-updater#47