### PR TITLE
Don't assume that the extra key exists in is_container_build

### DIFF
--- a/estuary_updater/handlers/base.py
+++ b/estuary_updater/handlers/base.py
@@ -76,7 +76,7 @@ class BaseHandler(object):
         :rtype: bool
         """
         pkg = build_info['package_name']
-        extra = build_info['extra']
+        extra = build_info.get('extra')
         # Checking heuristics for determining if a build is a container build, since currently
         # there is no definitive way to do it.
         if not extra:


### PR DESCRIPTION
Sometimes, the build info that is passed in is incomplete and doesn't contain the `extra` key. In this case, assume its an RPM and move on.