### PR TITLE
Show all identified images

### DIFF
--- a/estuary_updater/handlers/freshmaker.py
+++ b/estuary_updater/handlers/freshmaker.py
@@ -122,7 +122,6 @@ class FreshmakerHandler(BaseHandler):
         log.debug('Creating FreshmakerBuild {0}'.format(build['build_id']))
         fb_params = dict(
             id_=build['id'],
-            build_id=build['build_id'],
             dep_on=build['dep_on'],
             name=build['name'],
             original_nvr=build['original_nvr'],
@@ -138,6 +137,9 @@ class FreshmakerHandler(BaseHandler):
         if build['time_completed']:
             fb_params['time_completed'] = timestamp_to_datetime(
                 build['time_completed'])
+        if build['build_id']:
+            fb_params['build_id'] = build['build_id']
+
         return FreshmakerBuild.create_or_update(fb_params)[0]
 
     def create_or_update_build(self, build, event_id):


### PR DESCRIPTION
A recent change introduced the chance to see also failed Freshmaker
builds and not only the successful. Some of them seem to be skipped
due to failure building parent images. With this change they will
also be showed.
ref: FACTORY-4592

Signed-off-by: gnaponie <gnaponie@redhat.com>