### PR TITLE
Ignore Freshmaker events triggered by manual rebuilds in dry run mode

### DIFF
--- a/estuary_updater/handlers/freshmaker.py
+++ b/estuary_updater/handlers/freshmaker.py
@@ -51,6 +51,10 @@ class FreshmakerHandler(BaseHandler):
         :param dict msg: a message to be processed
         """
         msg_id = msg['body']['msg']['message_id']
+
+        if msg['body']['msg'].get('dry_run'):
+            return
+
         event_params = {
             'id_': str(msg['body']['msg']['id']),
             'event_type_id': msg['body']['msg']['event_type_id'],

--- a/tests/messages/freshmaker/event_to_building.json
+++ b/tests/messages/freshmaker/event_to_building.json
@@ -96,7 +96,8 @@
             "message_id": "ID:messaging.domain.com-42045-1527890187852-9:704208:0:0:1.RHBA-8018:0593-01",
             "state_name": "BUILDING",
             "time_created": "2019-08-21T13:42:20Z",
-            "time_done": null
+            "time_done": null,
+            "dry_run": false
         }
     },
     "topic": "/topic/VirtualTopic.eng.freshmaker.event.state.changed",


### PR DESCRIPTION
From [FACTORY-4870](https://projects.engineering.redhat.com/browse/FACTORY-4870)