### PR TITLE
Mock requests_kerberos when building the documentation

### DIFF
--- a/docs-requirements.txt
+++ b/docs-requirements.txt
@@ -4,7 +4,6 @@ neomodel
 PyOpenSSL
 recommonmark
 requests
-requests_kerberos
 sphinx
 sphinx_rtd_theme
 stomper

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -14,7 +14,7 @@ import pkg_resources
 from datetime import datetime
 
 
-autodoc_mock_imports = ['koji', 'fedmsg', 'fedmsg.config']
+autodoc_mock_imports = ['koji', 'fedmsg', 'fedmsg.config', 'requests_kerberos']
 
 
 # -- Path setup --------------------------------------------------------------


### PR DESCRIPTION
This is needed since Read the Docs doesn't have krb5-devel installed.